### PR TITLE
add igw and route table

### DIFF
--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,7 @@
+output "vpcs" {
+  value = local.flat_vpcs
+}
+
+output "subnets" {
+  value = local.flat_subnets
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -2,6 +2,8 @@ variable "vpc" {
     type = list(object({
         name = string
         cidr_block = string
+        attach_internet_gateway = bool
+        attach_route_table = bool
         subnets = list(object({
             name = string
             cidr_block = string

--- a/network.tf
+++ b/network.tf
@@ -19,6 +19,8 @@ locals {
     {
       name = "ps_release_can_vpc_001"
       cidr_block = "10.0.0.0/22"
+      attach_internet_gateway = true
+      attach_route_table = true
       subnets = [
         {
           name = "ps-release-can-subnet-001"
@@ -30,6 +32,22 @@ locals {
         }
       ]
     },
+    {
+      name = "this_is_test"
+      cidr_block = "17.0.0.0/22"
+      attach_internet_gateway = false
+      attach_route_table = false
+      subnets = [
+        {
+          name = "test-snet-00A"
+          cidr_block = "17.0.0.0/25"
+        },
+        {
+          name = "test-snet-00B"
+          cidr_block = "17.0.1.0/25"
+        }
+      ]
+    },
   ]
 }
 
@@ -37,4 +55,12 @@ module "release_network" {
   source = "./modules/network"
 
   vpc = local.vpc
+}
+
+output "vpcs" {
+  value = module.release_network.vpcs
+}
+
+output "subnets" {
+  value = module.release_network.subnets
 }


### PR DESCRIPTION
Adding Internet gateway(IGW) and Route table(RTB) 
Please note: the VPC creation also by default creates a route table . 
In the above PR we are making our own route table with route to internet , through the IGW

Other resources made by this PR:
Test VPC and subnets 
Test output variables
Flat VPCs made in locals , its usage needs to be assessed 

Test /Edge Cases:
Makes IGW for every VPC and does not make when values is false 
Makes RTB for every VPC and does not make when values is false 