### PR TITLE
define route table association

### DIFF
--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -4,7 +4,9 @@ locals {
     for subnet in vpc.subnets : {
       name = subnet.name
       cidr_block = subnet.cidr_block
+      vpc_name = vpc.name
       vpc_id = aws_vpc.main[vpc.name].id
+      public_subnet = subnet.public_subnet
     }
   ] 
  ])
@@ -31,6 +33,7 @@ resource "aws_subnet" "main" {
     Name = each.key
     Managed-By = "terraform"
     Env = "release"
+    public_subnet = each.value.public_subnet
   }
 }
 
@@ -51,4 +54,17 @@ resource "aws_route_table" "main" {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.main[each.key].id
   }
+}
+
+### In the below resource , please notice that the route table resource above is keyed using vpc.name 
+### So we have to have vpc name in our flat subnets struct
+### Then with the flat subnets struct, we check if public subnet == true AND keys of RTB resource above(which is vpc.name) - basically checking which VPCs have RTBs
+### in the last line of the resource below, we have to get the RTB IDs via. vpc.name , because of all above stated reasons.
+
+resource "aws_route_table_association" main {
+  for_each = { for subnet in local.flat_subnets : subnet.name => subnet
+  if subnet.public_subnet == true && contains(keys(aws_route_table.main), subnet.vpc_name )  # && since RTB is keyed by vpc.name, we use keys() function to get all VPCs that have RTB 
+   }
+  subnet_id = aws_subnet.main[each.key].id
+  route_table_id = aws_route_table.main[each.value.vpc_name].id   # we do this because , route table resource is 'Keyed' to `var.vpc` and in turn, `vpc.name`
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -7,6 +7,7 @@ variable "vpc" {
         subnets = list(object({
             name = string
             cidr_block = string
+            public_subnet = bool
         }))
     }))
 }

--- a/network.tf
+++ b/network.tf
@@ -25,10 +25,12 @@ locals {
         {
           name = "ps-release-can-subnet-001"
           cidr_block = "10.0.0.0/25"
+          public_subnet = true
         },
         {
           name = "ps-release-can-subnet-002"
           cidr_block = "10.0.1.0/25"
+          public_subnet = true
         }
       ]
     },


### PR DESCRIPTION
We are defining route table association for our subnets , these will provide internet traffic to our subnets. 
Only public subnets will have a route table attached , and VPCs which have a route table can have public subnets
