### PR TITLE
feat. add egress to SGs

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -26,8 +26,8 @@ module "release_vms" {
 }
 
 # import has to be in root module - will remove after its been removed
-import {
-  to = module.release_vms.aws_key_pair.logger
-  id = "project-site-logger" # "key-0588b2a6399ba705d"  
-}
+# import {
+#   to = module.release_vms.aws_key_pair.logger
+#   id = "logger" # "key-0588b2a6399ba705d"  
+# }
 

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -24,6 +24,6 @@ resource "aws_instance" "main" {
 }
 
 resource "aws_key_pair" "logger" {
-  key_name   = "project-site-logger"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTRREzdq/axPbJsK7n1vvjk+HyWLVkqROol0hhsaSAQmVvg/eu06Z4RJeLStLOrzGsn/XifaTmWzg1HrtJljGkW84rsEtWhwHwW+9jg62j/0oDbJoOw3ruVTns3XbEjC/nFr8vuIMWdvuNDqThABx/It2na8Hx5cT1nKY0mKA1B1L8IzCDlvFvaYUExl5G92Lu2EsqxaVwb7J3Q98QzX4/IeTbNuwA8dg9na2z4FRfQlNX9xzPH+tuImYIk4nss6sATmsAsWi2HLmvn4GlH1NOFezr5cbiOL+wihGJ+gVn3CNXyJLfUVkpJcoOqLGfppU/bT9Cw+vqYSOsb6KAI7cH project-site-logger"
+  key_name   = "logger"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOsQM+VqXjap1nHQszpeTbeykyFH3fWedyAB2u27NM3iQEsgm2ot9tzzdhouaPbctmCba1TU/4K0CKl+4US7hfYp3aMdu3wMHE1N8K8O3/3vIZ5ZijNDH8my5ocm8DVMyxVdRV0tn+z63NPPGEa4A7irJiWwlcOPIpwIF620/CctmyubOUQYUq8AMerxWTWmQugfUXcO8ezvYDMgsCATXD4fnwHOk33B+8TcB2ie20l5pW7kVegv3WP/WzHVe5C7ocHNegICMdI8Vn32DUPwX86JD6dNAfsNuO9y6a4rp96MxepgrZG62b3td5GKvdUNydeDGTnczVSqQ97rGAS8yB logger"
 }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -64,6 +64,7 @@ resource "aws_route_table" "main" {
 ### Then with the flat subnets struct, we check if public subnet == true AND keys of RTB resource above(which is vpc.name) - basically checking which VPCs have RTBs
 ### in the last line of the resource below, we have to get the RTB IDs via. vpc.name , because of all above stated reasons.
 
+# Associating subnets with route tables.
 resource "aws_route_table_association" "main" {
   for_each = { for subnet in local.flat_subnets : subnet.name => subnet
     if subnet.public_subnet == true && contains(keys(aws_route_table.main), subnet.vpc_name) # && since RTB is keyed by vpc.name, we use keys() function to get all VPCs that have RTB 
@@ -71,4 +72,3 @@ resource "aws_route_table_association" "main" {
   subnet_id      = aws_subnet.main[each.key].id
   route_table_id = aws_route_table.main[each.value.vpc_name].id # we do this because , route table resource is 'Keyed' to `var.vpc` and in turn, `vpc.name`
 }
-

--- a/modules/network/security-group.tf
+++ b/modules/network/security-group.tf
@@ -17,6 +17,7 @@ locals {
   #  so after merge , the structure looks as such : 
   #  {
   #   name        = "home-to-fastapi"
+  #   type        = "ingress"
   #   cidr_ipv4   = "x.x.x.x"
   #   ip_protocol = "tcp"
   #   from_port = 8000
@@ -25,7 +26,7 @@ locals {
   #  }
 
   security_group_rule_map = { for rule in local.flat_security_groups_rules :
-    "${rule.name}-${rule.to_port}-${rule.sg_name}" => rule
+    "${rule.name}-${rule.sg_name}" => rule
   }
 
   # we need to make a map to have a unique object ,
@@ -48,7 +49,16 @@ resource "aws_security_group" "main" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "main" {
-  for_each          = local.security_group_rule_map
+  for_each          = { for key, rule in local.security_group_rule_map : key => rule if rule.type == "ingress" }
+  cidr_ipv4         = each.value.cidr_ipv4
+  ip_protocol       = each.value.ip_protocol
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  security_group_id = aws_security_group.main[each.value.sg_name].id
+}
+
+resource "aws_vpc_security_group_egress_rule" "main" {
+  for_each          = { for key, rule in local.security_group_rule_map : key => rule if rule.type == "egress" }
   cidr_ipv4         = each.value.cidr_ipv4
   ip_protocol       = each.value.ip_protocol
   from_port         = each.value.from_port

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -17,9 +17,10 @@ variable "vpc" {
 variable "security_group_rules" {
   type = map(list(object({
     name        = string
+    type        = string
     cidr_ipv4   = string
     ip_protocol = string
-    from_port   = number
-    to_port     = number
+    from_port   = optional(number)
+    to_port     = optional(number)
   })))
 }

--- a/network.tf
+++ b/network.tf
@@ -92,8 +92,8 @@ locals {
       {
         name        = "vm-to-outside"
         type        = "egress"
-        cidr_ipv4   = "0.0.0.0/0"         # internet is needed for downloading packages.
-        ip_protocol = "-1"                # all traffic Egress, in this case ports not required.
+        cidr_ipv4   = "0.0.0.0/0" # internet is needed for downloading packages.
+        ip_protocol = "-1"        # all traffic Egress, in this case ports not required.
       }
     ],
     "ps-release-can-sg-reserve" = [
@@ -148,8 +148,8 @@ locals {
       {
         name        = "vm-to-outside"
         type        = "egress"
-        cidr_ipv4   = "0.0.0.0/0"         # internet is needed for downloading packages.
-        ip_protocol = "-1"                # all traffic Egress, in this case ports not required.
+        cidr_ipv4   = "0.0.0.0/0" # internet is needed for downloading packages.
+        ip_protocol = "-1"        # all traffic Egress, in this case ports not required.
       }
     ],
   }

--- a/network.tf
+++ b/network.tf
@@ -43,6 +43,7 @@ locals {
     "ps-release-can-sg-shared" = [
       {
         name        = "home-to-fastapi"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 8000
@@ -50,6 +51,7 @@ locals {
       },
       {
         name        = "office-to-fastapi"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 8000
@@ -57,6 +59,7 @@ locals {
       },
       {
         name        = "home-to-nginx"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 80
@@ -64,6 +67,7 @@ locals {
       },
       {
         name        = "office-to-nginx"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 80
@@ -71,6 +75,7 @@ locals {
       },
       {
         name        = "home-to-ssh"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 22
@@ -78,15 +83,23 @@ locals {
       },
       {
         name        = "office-to-ssh"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 22
         to_port     = 22
+      },
+      {
+        name        = "vm-to-outside"
+        type        = "egress"
+        cidr_ipv4   = "0.0.0.0/0"         # internet is needed for downloading packages.
+        ip_protocol = "-1"                # all traffic Egress, in this case ports not required.
       }
     ],
     "ps-release-can-sg-reserve" = [
       {
         name        = "home-to-fastapi"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 8000
@@ -94,6 +107,7 @@ locals {
       },
       {
         name        = "office-to-fastapi"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 8000
@@ -101,6 +115,7 @@ locals {
       },
       {
         name        = "home-to-nginx"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 80
@@ -108,6 +123,7 @@ locals {
       },
       {
         name        = "office-to-nginx"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 80
@@ -115,6 +131,7 @@ locals {
       },
       {
         name        = "home-to-ssh"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 22
@@ -122,10 +139,17 @@ locals {
       },
       {
         name        = "office-to-ssh"
+        type        = "ingress"
         cidr_ipv4   = "x.x.x.x"
         ip_protocol = "tcp"
         from_port   = 22
         to_port     = 22
+      },
+      {
+        name        = "vm-to-outside"
+        type        = "egress"
+        cidr_ipv4   = "0.0.0.0/0"         # internet is needed for downloading packages.
+        ip_protocol = "-1"                # all traffic Egress, in this case ports not required.
       }
     ],
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,5 +8,5 @@ terraform {
 }
 
 provider "aws" {
-  region                   = "ca-central-1"
+  region = "ca-central-1"
 }


### PR DESCRIPTION
This PR improves the following: 
## Network Module : 
- introducing Egress rules `aws_vpc_security_group_egress_rule` for Security Groups (used for downloading packages from internet)
- variable `security_group_rules` ' parameters `from_port` & `to_port` are now optional to support Egress rule's ip_protocol of -1

## Network Root : 
- specify type `ingress` or `egress` (string) in your Security group rules 

## Compute root : 
- import block for key pair not required , you instead make a key pair , use terraform import command and specify the public key in the state file. 
- This can change in the future


